### PR TITLE
Proc macro bug

### DIFF
--- a/examples/regression/mod.rs
+++ b/examples/regression/mod.rs
@@ -1,1 +1,0 @@
-automod::dir!("examples/regression");

--- a/examples/tests.rs
+++ b/examples/tests.rs
@@ -8,6 +8,8 @@
 //
 //    cargo test --example tests
 
-mod regression;
+mod regression {
+    automod::dir!("examples/regression");
+}
 
 fn main() {}


### PR DESCRIPTION
This should work but doesn't. Will need to file a rustc bug. Something about the call_site span doesn't realize that it is inside of an inline module.

```console
error[E0583]: file not found for module `issue128`
  --> examples/tests.rs:12:5
   |
12 |     automod::dir!("examples/regression");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: name the file either issue128.rs or issue128/mod.rs inside the directory "examples"
```