### PR TITLE
Ignore lib.rs and main.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ fn source_file_names<P: AsRef<Path>>(dir: P) -> Result<Vec<String>> {
         }
 
         let file_name = entry.file_name();
-        if file_name == "mod.rs" {
+        if file_name == "mod.rs" || file_name == "lib.rs" || file_name == "main.rs" {
             continue;
         }
 


### PR DESCRIPTION
If the automod macro points to a directory containing the crate's top level lib.rs or main.rs, presumably that top level source file is the one containing the automod call and should not be considered a module.