### PR TITLE
Inline the regression mod example after rustc bug fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.31.0]
+        rust: [nightly, beta, stable, 1.44.0]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
@@ -20,3 +20,10 @@ jobs:
           toolchain: ${{matrix.rust}}
       - run: cargo test
       - run: cargo test --example tests
+  msrv:
+    name: Rust 1.31.0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@1.31.0
+      - run: cargo test --doc

--- a/examples/regression/mod.rs
+++ b/examples/regression/mod.rs
@@ -1,1 +1,0 @@
-automod::dir!("examples/regression");

--- a/examples/tests.rs
+++ b/examples/tests.rs
@@ -8,6 +8,8 @@
 //
 //    cargo test --example tests
 
-mod regression;
+mod regression {
+    automod::dir!("examples/regression");
+}
 
 fn main() {}


### PR DESCRIPTION
This is made possible after rustc 1.44+ resolved the bug affecting #1 (https://github.com/rust-lang/rust/issues/58818).