### PR TITLE
Add directory mod support. Also add tests for it

### DIFF
--- a/tests/dir_mods/a/mod.rs
+++ b/tests/dir_mods/a/mod.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/dir_mods/b/mod.rs
+++ b/tests/dir_mods/b/mod.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/dir_mods/c/mod.rs
+++ b/tests/dir_mods/c/mod.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/dir_mods/mod.rs
+++ b/tests/dir_mods/mod.rs
@@ -1,0 +1,1 @@
+automod::dir!(pub "tests/dir_mods");

--- a/tests/file_mods/a.rs
+++ b/tests/file_mods/a.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/file_mods/b.rs
+++ b/tests/file_mods/b.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/file_mods/c.rs
+++ b/tests/file_mods/c.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/file_mods/mod.rs
+++ b/tests/file_mods/mod.rs
@@ -1,0 +1,1 @@
+automod::dir!(pub "tests/file_mods");

--- a/tests/mixed_mod_types/dir_mod/mod.rs
+++ b/tests/mixed_mod_types/dir_mod/mod.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/mixed_mod_types/file_mod.rs
+++ b/tests/mixed_mod_types/file_mod.rs
@@ -1,0 +1,1 @@
+pub fn mod_test() -> bool { true }

--- a/tests/mixed_mod_types/mod.rs
+++ b/tests/mixed_mod_types/mod.rs
@@ -1,0 +1,1 @@
+automod::dir!(pub "tests/mixed_mod_types");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,21 @@
+mod dir_mods;
+mod file_mods;
+mod mixed_mod_types;
+
+#[test]
+fn dir_mods_test() {
+    assert!(dir_mods::a::mod_test());
+    assert!(dir_mods::b::mod_test());
+    assert!(dir_mods::c::mod_test());
+}
+#[test]
+fn file_mods_test() {
+    assert!(file_mods::a::mod_test());
+    assert!(file_mods::b::mod_test());
+    assert!(file_mods::c::mod_test());
+}
+#[test]
+fn mixed_mod_types_test() {
+    assert!(mixed_mod_types::dir_mod::mod_test());
+    assert!(mixed_mod_types::file_mod::mod_test());
+}


### PR DESCRIPTION
I added support for loading directory based mods. I added some simple tests to check that the mods are all loading correctly. It simply uses dummy `mod_test` functions in each mod, as it's just a compilation time check. If the tests compile, the crate is working.