### PR TITLE
Add example of 'pub' modifier usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ mod issue2;
 mod issue128;
 ```
 
+Analogously, the generated module declarations can be markes as public:
+```rust
+mod regression {
+    automod::dir!(pub "tests/regression");
+}
+```
+
+Expanding to:
+```rust
+pub mod issue1;
+pub mod issue2;
+/* ... */
+pub mod issue128;
+```
+
+
 <br>
 
 #### License


### PR DESCRIPTION
After searching in the issues, I found this feature in issue #6. Currently this is not mentioned in the README at all. This PR adds a corresponding example.