### PR TITLE
Add support for numeric prefix file names and mod names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,19 +109,19 @@ pub fn dir(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-fn mod_item(vis: &Visibility, name: String) -> TokenStream2 {
-    if name.contains('-') {
-        let path = format!("{}.rs", name);
-        let ident = Ident::new(&name.replace('-', "_"), Span::call_site());
-        quote! {
-            #[path = #path]
-            #vis mod #ident;
-        }
-    } else {
-        let ident = Ident::new(&name, Span::call_site());
-        quote! {
-            #vis mod #ident;
-        }
+fn mod_item(vis: &Visibility, mut name: String) -> TokenStream2 {
+    let path = format!("{}.rs", name);
+
+    name = name.replace('-', "_");
+    if name.chars().next().unwrap().is_ascii_digit() {
+        name = format!("_{}", name)
+    }
+
+    let ident = Ident::new(&name, Span::call_site());
+
+    quote! {
+        #[path = #path]
+        #vis mod #ident;
     }
 }
 


### PR DESCRIPTION
For Rust source files named with a numeric prefix, lib will use `_{name}` as its mod name.

While it's not good practice to name source files with a numeric prefix, this handles my unusual case.
