### PR TITLE
Add support for symbolic links pointing to Rust source files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ fn source_file_names<P: AsRef<Path>>(dir: P) -> Result<Vec<String>> {
 
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
-        if !entry.file_type()?.is_file() {
+        if !fs::metadata(entry.path())?.is_file() {
             continue;
         }
 


### PR DESCRIPTION
In some rare use cases, there may be symlinks to source files instead of the actual source files. This PR adds support for symbolic links by traversing them before checking if a directory entry is a file.